### PR TITLE
output = json

### DIFF
--- a/R/oa_fetch.R
+++ b/R/oa_fetch.R
@@ -20,7 +20,8 @@ oa_entities <- function() {
 #' @param abstract Logical. If TRUE, the function returns also the abstract of each item.
 #' Default to \code{abstract = TRUE}.
 #' The argument is ignored if entity is different from "works".
-#' @param output Character. Type of output, either a list or a tibble/data.frame.
+#' @param output Character.
+#' Type of output, one of `"tibble"`, `"dataframe"`, `"list"`, or `"json"`.
 #'
 #' @return A data.frame or a list. Result of the query.
 #' @export
@@ -186,6 +187,8 @@ oa_fetch <- function(entity = if (is.null(identifier)) NULL else id_type(shorten
 #' Gives OpenAlex an email to enter the polite pool.
 #' @param api_key Character string.
 #' Your OpenAlex Premium API key, if available.
+#' @param parse Logical.
+#' If FALSE, returns the raw JSON response as string.
 #' @param verbose Logical.
 #' If TRUE, print information about the querying process. Defaults to TRUE.
 #'

--- a/man/oa_fetch.Rd
+++ b/man/oa_fetch.Rd
@@ -11,7 +11,7 @@ oa_fetch(
   options = NULL,
   search = NULL,
   group_by = NULL,
-  output = c("tibble", "dataframe", "list"),
+  output = c("tibble", "dataframe", "list", "json"),
   abstract = TRUE,
   endpoint = "https://api.openalex.org",
   per_page = 200,
@@ -66,7 +66,8 @@ To filter using search, append .search to the end of the attribute you're filter
 For example: "oa_status" for works.
 See more at <https://docs.openalex.org/how-to-use-the-api/get-groups-of-entities>.}
 
-\item{output}{Character. Type of output, either a list or a tibble/data.frame.}
+\item{output}{Character.
+Type of output, one of `"tibble"`, `"dataframe"`, `"list"`, or `"json"`.}
 
 \item{abstract}{Logical. If TRUE, the function returns also the abstract of each item.
 Default to \code{abstract = TRUE}.

--- a/man/oa_random.Rd
+++ b/man/oa_random.Rd
@@ -16,7 +16,8 @@ The argument can be one of
 c("works", "authors", "institutions", "concepts", "funders", "sources", "publishers", "topics").
 If not provided, `entity` is guessed from `identifier`.}
 
-\item{output}{Character. Type of output, either a list or a tibble/data.frame.}
+\item{output}{Character.
+Type of output, one of `"tibble"`, `"dataframe"`, `"list"`, or `"json"`.}
 
 \item{endpoint}{Character. URL of the OpenAlex Endpoint API server.
 Defaults to endpoint = "https://api.openalex.org".}

--- a/man/oa_request.Rd
+++ b/man/oa_request.Rd
@@ -12,6 +12,7 @@ oa_request(
   count_only = FALSE,
   mailto = oa_email(),
   api_key = oa_apikey(),
+  parse = TRUE,
   verbose = FALSE
 )
 }
@@ -43,6 +44,9 @@ Gives OpenAlex an email to enter the polite pool.}
 
 \item{api_key}{Character string.
 Your OpenAlex Premium API key, if available.}
+
+\item{parse}{Logical.
+If FALSE, returns the raw JSON response as string.}
 
 \item{verbose}{Logical.
 If TRUE, print information about the querying process. Defaults to TRUE.}


### PR DESCRIPTION
Support `output = "json"`, mainly by adding an argument to `api_request(parse=TRUE)` to toggle whether the JSON response is parsed or kept raw. 

This creates a simple equivalence between `output = "list"` and `output = "json"`, where you can get from JSON -> list by parsing and merging the JSON contents:

```r
parsed <- oa_fetch(
  entity = "works",
  search = "language",
  per_page = 2,
  options = list(sample = 5, seed = 1),
  output = "list"
)

raw <- oa_fetch(
  entity = "works",
  search = "language",
  per_page = 2,
  options = list(sample = 5, seed = 1),
  output = "json"
)

raw2parsed <- function(x) {
  parsed <- lapply(x, jsonlite::fromJSON, simplifyVector = FALSE)
  results <- lapply(parsed, `[[`, "results")
  unlist(results, recursive = FALSE, use.names = FALSE)
}

waldo::compare(
  parsed, 
  raw2parsed(raw),
  list_as_map = TRUE # some list element order diffs from extra-processing in output = "list"
)
#> ✔ No differences
```

For the power user, swapping the parsing engine can be done like so:

```r
# Use {RcppSimdJson} instead
raw2parsed_fast <- function(x) {
  parsed <- lapply(x, RcppSimdJson::fparse, max_simplify_lvl = 3L, empty_array = list())
  results <- lapply(parsed, `[[`, "results")
  unlist(results, recursive = FALSE, use.names = FALSE)
}

bench::mark(
  raw2parsed(raw),
  raw2parsed_fast(raw)
)
#> # A tibble: 2 × 6
#>   expression                min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>           <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 raw2parsed(raw)        1.44ms   1.66ms      544.    12.5KB     2.03
#> 2 raw2parsed_fast(raw)  510.1µs  618.1µs     1273.    12.5KB     2.04
```

openalexR can minimally support this `output = "json"` as option as "dumping what we get back, as-is", and it's the responsibility of power users (not maintainers) to build on top of this with their pet JSON processing workflows. e.g., if you want to download the json files to read them back in using duckdb, you do *all* that work outside:

```r
json_dir <- file.path(tempdir(), "test-json")
dir.create(json_dir)
for (i in seq_along(raw)) {
  writeLines(raw[[i]], file.path(json_dir, paste0("res", i, ".json")))
}
fs::dir_tree(json_dir)
#> C:\Users\jchoe\AppData\Local\Temp\Rtmpaaj6wC/test-json
#> ├── res1.json
#> ├── res2.json
#> └── res3.json

library(duckdb)
con <- dbConnect(duckdb())
dbExecute(con, "INSTALL json; LOAD json;")
tbl <- dbGetQuery(con, sprintf("
  SELECT
    UNNEST(results, max_depth := 2)
  FROM
    read_ndjson('%s/*.json', maximum_object_size=1000000000, ignore_errors=true)
", normalizePath(json_dir)))
dbDisconnect(con)

tibble::as_tibble(tbl)
#> # A tibble: 5 × 51
#>   id       doi   title display_name relevance_score publication_year publication_date ids$openalex language
#>   <chr>    <chr> <chr> <chr>                  <dbl>            <dbl> <date>           <chr>        <chr>   
#> 1 https:/… http… Psyc… Psychometri…            1.00             2020 2020-05-01       https://ope… en      
#> 2 https:/… http… REVI… REVIEWS                 1.00             1984 1984-01-01       https://ope… <NA>    
#> 3 https:/… http… Intr… Introduction            1.00             2005 2005-09-01       https://ope… en      
#> 4 https:/… http… Enco… Encouraging…            1.00             2017 2017-09-23       https://ope… en      
#> 5 https:/… http… Phon… Phoneme tra…            1.00             2004 2004-03-01       https://ope… en      
#> # ℹ 45 more variables: ids$doi <chr>, $mag <chr>, $pmid <chr>, primary_location <df[,9]>, type <chr>,
#> #   type_crossref <chr>, indexed_in <list>, open_access <df[,4]>, authorships <list>,
#> #   countries_distinct_count <dbl>, institutions_distinct_count <dbl>, corresponding_author_ids <list>,
#> #   corresponding_institution_ids <list>, apc_list <df[,4]>, apc_paid <chr>, fwci <dbl>,
#> #   has_fulltext <lgl>, cited_by_count <dbl>, citation_normalized_percentile <df[,3]>,
#> #   cited_by_percentile_year <df[,2]>, biblio <df[,4]>, is_retracted <lgl>, is_paratext <lgl>,
#> #   primary_topic <df[,6]>, topics <list>, keywords <list>, concepts <list>, mesh <list>, …
```